### PR TITLE
Search first heading content more properly.

### DIFF
--- a/foliant/backends/mkdocs.py
+++ b/foliant/backends/mkdocs.py
@@ -66,7 +66,7 @@ class Backend(BaseBackend):
 
             with open(page_file_full_path, encoding='utf8') as page_file:
                 content = page_file.read()
-                headings_found = re.search("^#+\s+(.+)$", content, flags=re.MULTILINE)
+                headings_found = re.search("^\s*#{1,6}[ \t]+([^\r\n]+?)(?:[ \t]+\{#\S+\})?\s*[\r\n]+", content)
 
                 if headings_found:
                     first_heading = headings_found.group(1)


### PR DESCRIPTION
We may have anything horrible in source Markdown before linting/prettifying (CR, tabs, etc.)

Also we have to parse headings with Pandoc-style IDs correctly: `# Heading {#custom_id}`.